### PR TITLE
users/items/show sign_in button_to > link_to

### DIFF
--- a/app/views/users/items/show.html.erb
+++ b/app/views/users/items/show.html.erb
@@ -33,7 +33,7 @@
 						</p>
 					<% else %>
 						<p>
-							<%= button_to "カートに入れる", new_user_session_path %>
+							<%= link_to "カートに入れる", new_user_session_path %>
 						</p>
 					<% end %>
 				<% end %>


### PR DESCRIPTION
ログアウト状態でカートへ入れるを押すとリンク先がcreateアクションに飛ぶバグを修正